### PR TITLE
exception-catching function to automatically save .dump file(2)

### DIFF
--- a/pydumpling/__init__.py
+++ b/pydumpling/__init__.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from .rpdb import r_post_mortem
 from .debug_dumpling import debug_dumpling, load_dumpling
 from .pydumpling import save_dumping, dump_current_traceback, __version__
+from .helpers import catch_any_exception
 
 
 __version__ == __version__

--- a/pydumpling/helpers.py
+++ b/pydumpling/helpers.py
@@ -21,4 +21,4 @@ def catch_any_exception():
         save_dumping(exc_info=(exc_type, exc_value, exc_tb))
         original_hook(exc_type, exc_value, exc_tb)  # call sys original hook
 
-    sys.excepthook = original_hook
+    sys.excepthook = _hook

--- a/pydumpling/helpers.py
+++ b/pydumpling/helpers.py
@@ -1,4 +1,6 @@
+import sys
 from traceback import print_tb, print_exception
+from .pydumpling import save_dumping
 
 
 def print_traceback_and_except(dumpling_result):
@@ -10,3 +12,13 @@ def print_traceback_and_except(dumpling_result):
         print_exception(exc_type, exc_value, exc_tb)
     else:
         print_tb(exc_tb)
+
+
+def catch_any_exception():
+    original_hook = sys.excepthook
+
+    def _hook(exc_type, exc_value, exc_tb):
+        save_dumping(exc_info=(exc_type, exc_value, exc_tb))
+        original_hook(exc_type, exc_value, exc_tb)  # call sys original hook
+
+    sys.excepthook = original_hook

--- a/pydumpling/pydumpling.py
+++ b/pydumpling/pydumpling.py
@@ -11,13 +11,15 @@ from .fake_types import FakeFrame, FakeTraceback
 __version__ = "0.1.4"
 
 
-def save_dumping(filename=None, tb=None):
+def save_dumping(filename=None, exc_info=None):
     try:
-        if tb is None:
+        if exc_info is None:
             exc_type, exc_value, exc_tb = sys.exc_info()
+        else:
+            exc_type, exc_value, exc_tb = exc_info
 
         if filename is None:
-            filename = "%s:%d.dump" % (
+            filename = "%s-%d.dump" % (
                 exc_tb.tb_frame.f_code.co_filename, exc_tb.tb_frame.f_lineno)
 
         fake_tb = FakeTraceback(exc_tb)


### PR DESCRIPTION
相对于前一次的pull request #22 , 这次改动有以下几点：
- 生成dump文件，之后继续把异常抛出来
- 对 `save_dumpling` 代码进行重写，使其可以重用

使用
```python
from pydumpling.helpers import catch_any_exception

catch_any_exception()

# your code
```