### PR TITLE
feat: add project.scripts to use pydumpling easy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "pydumpling"
-version = "0.1.6"
+version = "0.1.7"
 description = "Python post-mortem debugger"
 authors = [
     {name = "cocolato", email = "haiizhu@outlook.com"},
@@ -50,3 +50,6 @@ doc = [
     "sphinx-tabs>=3.4.5",
     "sphinx-copybutton>=0.5.2",
 ]
+
+[project.scripts]
+pydumpling = "pydumpling.__main__:main"


### PR DESCRIPTION
- 新增 project.scripts 配置以允许通过 `pydumpling` 命令直接运行项目脚本

目前可通过 `pydumpling` 命令直接运行项目脚本, 而不是通过 `python -m pydumpling`